### PR TITLE
Use *ring* in the canonical way.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ readme = "README.md"
 
 [dependencies]
 rustc-serialize = "0.3.16"
-constant_time_eq = "0.1.0"
 time = "0.1.32"
 byteorder = "0.3.13"
 ring = { git = "https://github.com/briansmith/ring" }


### PR DESCRIPTION
1. Do HMAC verification using |ring::hmac::verify| as recommended in
   the _ring_ documentation. This allows the dependency on
   constant_time_eq to be dropped.
2. Instead of creating a temporary HMAC key in each sign/verify
   operation, calculate the HMAC key once and reuse the same key multiple
   times. This is more efficient as the creation of an HMAC key is not
   free.
3. Do not store |salt| seperately. |salt| has already been mixed into
   |s_key| and |v_key| so it isn't needed any more.
